### PR TITLE
Adding placeholders and conditional labels

### DIFF
--- a/bootinput.js
+++ b/bootinput.js
@@ -1,6 +1,6 @@
 Vue.component('boot-input', {
-    template: '<div v-bind:class="{\'has-error\':error.length>0}" class="form-group"><label class="control-label">{{ label }}</label><input :type="type" class="form-control" v-model="model" :value="value" /><p class="help-block">{{ error[0] }}</p></div>',
-    props: ['model', 'type', 'value', 'error', 'label'],
+    template: '<div v-bind:class="{\'has-error\':error.length>0}" class="form-group"><label v-if="label" class="control-label">{{ label }}</label><input :type="type" class="form-control" v-model="model" :value="value" :placeholder="placeholder"/><p class="help-block">{{ error[0] }}</p></div>',
+    props: ['model', 'type', 'value', 'error', 'label','placeholder'],
     ready: function () {
         this.error = [];
     }
@@ -8,16 +8,16 @@ Vue.component('boot-input', {
 
 
 Vue.component('boot-textarea', {
-    template: '<div v-bind:class="{\'has-error\':error.length>0}" class="form-group"><label class="control-label">{{ label }}</label><textarea class="form-control" rows="3" cols="30" v-model="model" :value="value" /><p class="help-block">{{ error[0] }}</p></div>',
-    props: ['model', 'value', 'error', 'label'],
+    template: '<div v-bind:class="{\'has-error\':error.length>0}" class="form-group"><label v-if="label" class="control-label">{{ label }}</label><textarea class="form-control" rows="3" cols="30" v-model="model" :value="value" :placeholder="placeholder"/><p class="help-block">{{ error[0] }}</p></div>',
+    props: ['model', 'value', 'error', 'label','placeholder'],
     ready: function () {
         this.error = [];
     }
 });
 
 Vue.component('boot-select', {
-    template: '<div v-bind:class="{\'has-error\':error.length>0}" class="form-group"><label class="control-label">{{ label }}</label><select class="form-control" v-model="model"><option v-for="(key,option) in options" value="{{key}}">{{option}}</option></select><p class="help-block">{{ error[0] }}</p></div>',
-    props: ['model', 'value', 'error', 'label','options'],
+    template: '<div v-bind:class="{\'has-error\':error.length>0}" class="form-group"><label  v-if="label" class="control-label">{{ label }}</label><select class="form-control" v-model="model"><option v-if="placeholder" value=''>{{ placeholder }}</option><option v-for="(key,option) in options" value="{{key}}">{{option}}</option></select><p class="help-block">{{ error[0] }}</p></div>',
+    props: ['model', 'value', 'error', 'label','options','placeholder'],
     ready: function () {
         this.error = [];
     }


### PR DESCRIPTION
Adding in placeholder support with 'placeholder' parameter, which adds ghosted text to inputs and an 'empty' value for selects. Labels are conditional and won't show when not provided (there may be CSS consequences for having labels when not wanted).
